### PR TITLE
script: test for existence of state file, not executable status

### DIFF
--- a/script/publish
+++ b/script/publish
@@ -5,7 +5,7 @@ set -e
 
 docker login -e ${email} -u ${user} -p ${pass}
 
-if [ -x /dev/shm/publish_state ]; then
+if [ -e /dev/shm/publish_state ]; then
   docker push jumanjiman/state:${CACHED_REF}
   docker push jumanjiman/state:latest
 fi


### PR DESCRIPTION
We touch the semaphore in script/build, and
I meant to test for existence originally.