### PR TITLE
ci: improve cache handling for state image

### DIFF
--- a/script/build
+++ b/script/build
@@ -30,20 +30,18 @@ fi
 STATE_GIT_REF=$(git rev-list --abbrev-commit --max-count 1 HEAD -- state/Dockerfile)
 
 if [ "x${CACHED_REF}" != "x${STATE_GIT_REF}" ]; then
-  TAG=${GIT_REF}
-
   docker build \
     --rm=false \
-    --build-arg GIT_REF=${GIT_REF} \
+    --build-arg GIT_REF=${STATE_GIT_REF} \
     -t jumanjiman/state \
     state/
 
-  docker tag jumanjiman/state jumanjiman/state:${TAG}
+  docker tag jumanjiman/state jumanjiman/state:${STATE_GIT_REF}
   touch /dev/shm/publish_state
 
   if [ -d ~/deps ]; then
     rm -f ~/deps/state.tar || :
-    docker save -o ~/deps/state.tar jumanjiman/state
+    docker save -o ~/deps/state.tar jumanjiman/state jumanjiman/state:${STATE_GIT_REF}
   fi
 fi
 

--- a/script/publish
+++ b/script/publish
@@ -6,8 +6,10 @@ set -e
 docker login -e ${email} -u ${user} -p ${pass}
 
 if [ -e /dev/shm/publish_state ]; then
-  docker push jumanjiman/state:${CACHED_REF}
-  docker push jumanjiman/state:latest
+  # Latest git ref for "state/Dockerfile".
+  STATE_GIT_REF=$(git rev-list --abbrev-commit --max-count 1 HEAD -- state/Dockerfile)
+
+  docker push jumanjiman/state:${STATE_GIT_REF}
 fi
 
 for image in $(docker images | awk '/jumanjiman\/devenv/ {print $1":"$2 }'); do


### PR DESCRIPTION
Before this commit, we accidentally tagged the state image
with the latest git ref from the repo.

After this commit, we tag the state image with the latest git ref
of the state/Dockerfile.