### PR TITLE
remove deprecated option from ssh client config

### DIFF
--- a/app/etc/ssh/ssh_config
+++ b/app/etc/ssh/ssh_config
@@ -32,7 +32,6 @@ Host *
     MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-ripemd160-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,hmac-ripemd160,umac-128@openssh.com
     Port 22
     Protocol 2
-    RhostsRSAAuthentication no
     SendEnv LANG
     SendEnv LANGUAGE
     SendEnv LC_ADDRESS


### PR DESCRIPTION
This avoids warning:

    /etc/ssh/ssh_config line 35: Unsupported option "rhostsrsaauthentication"