### PR TITLE
app: upgrade to openssh 7.6p1

### DIFF
--- a/app/etc/hc/build.d/goss.yaml
+++ b/app/etc/hc/build.d/goss.yaml
@@ -22,7 +22,7 @@ package:
   docker:
     installed: true
     versions:
-      - 17.10.0-r0
+      - 17.12.0-r0
 user:
   root:
     exists: true

--- a/app/etc/package-lists
+++ b/app/etc/package-lists
@@ -11,7 +11,7 @@ libressl
 man
 man-pages
 mdocml-apropos
-openssh
+openssh">=7.6p1"
 openssh-client
 "
 

--- a/app/etc/ssh/ssh_config
+++ b/app/etc/ssh/ssh_config
@@ -29,7 +29,7 @@ Host *
     HostbasedAuthentication no
     IdentityFile ~/.ssh/id_rsa
     KexAlgorithms curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256
-    MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-ripemd160-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,hmac-ripemd160,umac-128@openssh.com
+    MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com
     Port 22
     Protocol 2
     SendEnv LANG
@@ -48,4 +48,5 @@ Host *
     SendEnv LC_TELEPHONE
     SendEnv LC_TIME
     SendEnv XMODIFIERS
-    StrictHostKeyChecking ask
+    # Automatically accept hitherto-unseen keys but will refuse connections for changed or invalid hostkeys.
+    StrictHostKeyChecking accept-new

--- a/app/etc/ssh/sshd_config
+++ b/app/etc/ssh/sshd_config
@@ -51,7 +51,7 @@ Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.
 
 # Encryption provides confidentiality;
 # message authentication code provides integrity.
-MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-ripemd160-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,hmac-ripemd160,umac-128@openssh.com
+MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com
 
 
 # Use strong, perfect forward secrecy for key exchange

--- a/ci/build
+++ b/ci/build
@@ -15,7 +15,7 @@ declare -rx TAG=\${BUILD_DATE}-git-\${GIT_REF}
 declare -rx CI_BUILD_URL="${CIRCLE_BUILD_URL:-unknown}"
 
 # Which version of Docker do we install in the image?
-declare -rx DOCKER_VERSION=17.10.0-r0
+declare -rx DOCKER_VERSION=17.12.0-r0
 EOF
 
 . ci/functions.sh


### PR DESCRIPTION
Remove hmac-ripemd160 MAC from the ssh config since
it's no longer available.

Use the new value to autamatically accept "new" host keys
but reject them if they change.

https://www.openssh.com/txt/release-7.6