### PR TITLE
allow scp when not using MFA

### DIFF
--- a/app/usr/sbin/user_login
+++ b/app/usr/sbin/user_login
@@ -15,7 +15,12 @@ readonly duo="${DUO:-true}"
 #readonly client_ip
 
 if [[ "${duo}" == true ]]; then
+  # login_duo handles both interactive and scp.
   exec /usr/sbin/login_duo -c "/etc/duo/${DUO_USERNAME}.conf" -f "${DUO_USERNAME}"
+elif [[ -n "${SSH_ORIGINAL_COMMAND:-}" ]]; then
+  # Allow scp without duo.
+  exec /bin/bash -c "${SSH_ORIGINAL_COMMAND}"
 else
+  # Interactive shell.
   exec /bin/bash -l
 fi


### PR DESCRIPTION
Before this commit, scp is broken because we fall back to
interactive shell.

After this commit, detect whether user is running a remote
command such as scp and do it.